### PR TITLE
Buffer is undefined when updating an attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ assign(AttributeMesh.prototype, {
     } else { // update existing
       // mutate existing attribute info like stride/etc
       assign(attrib, opt)
+      buffer = attrib.buffer
       buffer.usage = defined(opt.usage, buffer.usage)
       buffer.update(array)
     }


### PR DESCRIPTION
I had an error when trying to update an attribute. It was because the buffer object was empty when in non attribute mode. The fix is to grab the buffer from the attrib object.
